### PR TITLE
use read() for read_channel() instead of i2c

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate byteorder;
 extern crate embedded_hal as hal;
 


### PR DESCRIPTION
use self.read() for read_channel() since it seems to work better. simplifies things a lot, too.
hardcode shunt resistance to 10m.